### PR TITLE
Add lighthouse performance check to CI

### DIFF
--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,0 +1,12 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", {"aggregationMethod": "optimistic", "minScore": 0.7}],
+        "categories:accessibility": ["error", {"aggregationMethod": "optimistic", "minScore": 0.8}],
+        "categories:best-practices": ["error", {"aggregationMethod": "optimistic", "minScore": 0.8}],
+        "categories:seo": ["error", {"aggregationMethod": "optimistic", "minScore": 0.85}]
+      }
+    }
+  }
+}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,23 @@
+name: Lighthouse CI
+on:
+  schedule:
+    - cron: '0 20 * * *'
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v10
+        with:
+          urls: |
+            https://brightinventions.pl/
+            https://brightinventions.pl/about-us/
+            https://brightinventions.pl/what-we-offer/
+            https://brightinventions.pl/projects/
+            https://brightinventions.pl/career/
+            https://brightinventions.pl/blog/
+            https://brightinventions.pl/start-project/
+          temporaryPublicStorage: true
+          configPath: ./.github/lighthouse/lighthouserc.json
+          runs: 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,3 +117,23 @@ jobs:
             public
             .cache
           key: ${{ runner.os }}-gatsby-build-v29-${{ github.ref_name }}
+
+      - name: Audit URLs using Lighthouse
+        if: ${{ github.ref == 'refs/heads/gatsby' }}
+        uses: treosh/lighthouse-ci-action@v10
+        with:
+          urls: |
+            https://brightinventions.pl/
+          temporaryPublicStorage: true
+          configPath: ./.github/lighthouse/lighthouserc.json
+          runs: 3
+
+      - name: Audit URLs using Lighthouse
+        if: ${{ github.ref == 'refs/heads/staging' }}
+        uses: treosh/lighthouse-ci-action@v10
+        with:
+          urls: |
+            https://staging.brightinventions.pl/
+          temporaryPublicStorage: true
+          configPath: ./.github/lighthouse/lighthouserc.json
+          runs: 3


### PR DESCRIPTION
Add lighthouse performance check to CI:
- audit the main page URL on push to staging/gatsby
- audit production subpages URLs on schedule