### PR TITLE
Adjust lighthouse performance check

### DIFF
--- a/.github/lighthouse/main-lighthouserc.json
+++ b/.github/lighthouse/main-lighthouserc.json
@@ -2,7 +2,7 @@
   "ci": {
     "assert": {
       "assertions": {
-        "categories:performance": ["error", {"aggregationMethod": "optimistic", "minScore": 0.5}],
+        "categories:performance": ["error", {"aggregationMethod": "optimistic", "minScore": 0.7}],
         "categories:accessibility": ["error", {"aggregationMethod": "optimistic", "minScore": 0.8}],
         "categories:best-practices": ["error", {"aggregationMethod": "optimistic", "minScore": 0.8}],
         "categories:seo": ["error", {"aggregationMethod": "optimistic", "minScore": 0.85}]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
           urls: |
             https://brightinventions.pl/
           temporaryPublicStorage: true
-          configPath: ./.github/lighthouse/lighthouserc.json
+          configPath: ./.github/lighthouse/main-lighthouserc.json
           runs: 3
 
       - name: Audit URLs using Lighthouse
@@ -135,5 +135,5 @@ jobs:
           urls: |
             https://staging.brightinventions.pl/
           temporaryPublicStorage: true
-          configPath: ./.github/lighthouse/lighthouserc.json
+          configPath: ./.github/lighthouse/main-lighthouserc.json
           runs: 3


### PR DESCRIPTION
Adjust the lighthouse performance check:
- `"minScore": 0.7` for the main page - audit on push to staging/gatsby
- `"minScore": 0.5` for the subpages - audit on schedule